### PR TITLE
Add rrule_from_frule macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,9 @@ ChainRulesCore = "1.0.0"
 julia = "1"
 
 [extras]
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "ChainRulesTestUtils", "Zygote"]

--- a/src/ChainRulesDeclarationHelpers.jl
+++ b/src/ChainRulesDeclarationHelpers.jl
@@ -1,3 +1,4 @@
 module ChainRulesDeclarationHelpers
+    export @rrule_from_frule
     include("rrule_from_frule.jl")
 end  # module

--- a/src/ChainRulesDeclarationHelpers.jl
+++ b/src/ChainRulesDeclarationHelpers.jl
@@ -1,3 +1,3 @@
 module ChainRulesDeclarationHelpers
-
+    include("rrule_from_frule.jl")
 end  # module

--- a/src/rrule_from_frule.jl
+++ b/src/rrule_from_frule.jl
@@ -15,24 +15,20 @@ Further Reading
 """
 macro rrule_from_frule(signature_expression)
     @assert Meta.isexpr(signature_expression, :call)
-    @assert length(signature_expression.args) == 2 "Only single-argument functions are implemented."
-    # TODO add support for multiple arguments, varargs, kwargs
-
     f = signature_expression.args[1]
-    arg = signature_expression.args[2]
-    @assert Meta.isexpr(arg, :(::), 2)
-
-    return rrule_from_frule_expr(__source__, f, arg)
+    args = signature_expression.args[2:end]
+    @assert all(Meta.isexpr.(args, :(::), 2))
+    return rrule_from_frule_expr(__source__, f, args)
 end
 
-function rrule_from_frule_expr(__source__, f, arg)
+function rrule_from_frule_expr(__source__, f, args)
     f_instance_name  = gensym(Symbol(:instance_, Symbol(f)))
     return quote
-        function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, $f_instance_name::Core.Typeof($(esc(f))), $arg)
+        function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, $f_instance_name::Core.Typeof($(esc(f))), $(args...))
             $(__source__)
-            pushforward(Δfarg...) = frule(Δfarg, $f_instance_name, $arg)[2]
-            _, back = rrule_via_ad(config, pushforward, $f_instance_name, $arg)
-            y = $f_instance_name($arg) # TODO optimize away redundant primal computation
+            pushforward(Δfarg...) = frule(Δfarg, $f_instance_name, $(args...))[2]
+            _, back = rrule_via_ad(config, pushforward, $f_instance_name, $(args...))
+            y = $f_instance_name($(args...)) # TODO optimize away redundant primal computation
             f_pullback(Δy) = back(Δy)[2:end]
             return y, f_pullback
         end

--- a/src/rrule_from_frule.jl
+++ b/src/rrule_from_frule.jl
@@ -4,6 +4,10 @@ using ChainRulesCore
     @rrule_from_frule(signature_expression)
 
 A helper to define an rrule by calling back into AD on an already defined frule.
+The pushforward at the point is a linear function which has the same derivative as
+the primal at that point. So asking for its derivative gives you the derivative of 
+the primal. Moreover, asking for its rrule effectively amounts to transposing the 
+pushforward implied by the frule.
 """
 macro rrule_from_frule(signature_expression)
     @assert Meta.isexpr(signature_expression, :call)

--- a/src/rrule_from_frule.jl
+++ b/src/rrule_from_frule.jl
@@ -20,7 +20,7 @@ end
 function rrule_from_frule_expr(__source__, f, arg)
     f_instance_name  = gensym(Symbol(:instance_, Symbol(f)))
     return quote
-        function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, $f_instance_name::Core.Typeof($f), $arg)
+        function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, $f_instance_name::Core.Typeof($(esc(f))), $arg)
             $(__source__)
             pushforward(Δfarg...) = frule(Δfarg, $f_instance_name, $arg)[2]
             _, back = rrule_via_ad(config, pushforward, $f_instance_name, $arg)

--- a/src/rrule_from_frule.jl
+++ b/src/rrule_from_frule.jl
@@ -1,0 +1,32 @@
+using ChainRulesCore
+
+"""
+    @rrule_from_frule(signature_expression)
+
+A helper to define an rrule by calling back into AD on an already defined frule.
+"""
+macro rrule_from_frule(signature_expression)
+    @assert Meta.isexpr(signature_expression, :call)
+    @assert length(signature_expression.args) == 2 "Only single-argument functions are implemented."
+    # TODO add support for multiple arguments, varargs, kwargs
+
+    f = signature_expression.args[1]
+    arg = signature_expression.args[2]
+    @assert Meta.isexpr(arg, :(::), 2)
+
+    return rrule_from_frule_expr(__source__, f, arg)
+end
+
+function rrule_from_frule_expr(__source__, f, arg)
+    f_instance_name  = gensym(Symbol(:instance_, Symbol(f)))
+    return quote
+        function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, $f_instance_name::Core.Typeof($f), $arg)
+            $(__source__)
+            pushforward(Δfarg...) = frule(Δfarg, $f_instance_name, $arg)[2]
+            _, back = rrule_via_ad(config, pushforward, $f_instance_name, $arg)
+            y = $f_instance_name($arg) # TODO optimize away redundant primal computation
+            f_pullback(Δy) = back(Δy)[2:end]
+            return y, f_pullback
+        end
+    end
+end

--- a/src/rrule_from_frule.jl
+++ b/src/rrule_from_frule.jl
@@ -8,6 +8,10 @@ The pushforward at the point is a linear function which has the same derivative 
 the primal at that point. So asking for its derivative gives you the derivative of 
 the primal. Moreover, asking for its rrule effectively amounts to transposing the 
 pushforward implied by the frule.
+
+Further Reading
+[1] Roy Frostig, Matthew J. Johnson, Dougal Maclaurin, Adam Paszke, and Alexey Radul.
+    Decomposing reverse-mode automatic differentiation. LAFI 2021
 """
 macro rrule_from_frule(signature_expression)
     @assert Meta.isexpr(signature_expression, :call)

--- a/test/rrule_from_frule.jl
+++ b/test/rrule_from_frule.jl
@@ -1,21 +1,47 @@
 @testset "rrule_from_frule" begin
-    function f(x)
-        a = sin.(x)
-        b = sum(a)
-        c = b * a
-        return c
-    end
+    @testset "single argument" begin
+        function f(x)
+            a = sin.(x)
+            b = sum(a)
+            c = b * a
+            return c
+        end
+        
+        function ChainRulesCore.frule((Δself, Δx), ::typeof(f), x)
+            a, ȧ = sin.(x), cos.(x) .* Δx 
+            b, ḃ = sum(a), sum(ȧ)
+            c, ċ = b * a, ḃ * a + b * ȧ
+            return c, ċ
+        end
+        
+        x = rand(3)
+        test_frule(f, x)
     
-    function ChainRulesCore.frule((Δself, Δx), ::typeof(f), x)
-        a, ȧ = sin.(x), cos.(x) .* Δx 
-        b, ḃ = sum(a), sum(ȧ)
-        c, ċ = b * a, ḃ * a + b * ȧ
-        return c, ċ
+        @rrule_from_frule f(x::AbstractArray{<:Real})
+        test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)    
     end
+    @testset "multiple arguments" begin
+        function f(x, z)
+            a = x + z
+            b = sin.(a)
+            c = sum(b)
+            d = c * b
+            return d
+        end
+        
+        function ChainRulesCore.frule((Δself, Δx, Δz), ::typeof(f), x, z)
+            a, ȧ = x + z, Δx + Δz
+            b, ḃ = sin.(a), cos.(a) .* ȧ
+            c, ċ = sum(b), sum(ḃ)
+            d, ḋ = c * b, ċ * b + c * ḃ
+            return d, ḋ
+        end
+        
+        x = rand(3)
+        z = rand(3)
+        test_frule(f, x, z)
     
-    x = rand(3)
-    test_frule(f, x)
-
-    @rrule_from_frule f(x::AbstractArray{<:Real})
-    test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)
+        @rrule_from_frule f(x::AbstractArray{<:Real}, z::AbstractArray{<:Real})
+        test_rrule(Zygote.ZygoteRuleConfig(), f, x, z; check_inferred=false)    
+    end
 end

--- a/test/rrule_from_frule.jl
+++ b/test/rrule_from_frule.jl
@@ -21,8 +21,8 @@ using Zygote
     end
     
     x = rand(3)
-    @test test_frule(f, x)
+    test_frule(f, x)
 
     @rrule_from_frule f(x::AbstractArray{<:Real})
-    @test test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)
+    test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)
 end

--- a/test/rrule_from_frule.jl
+++ b/test/rrule_from_frule.jl
@@ -1,0 +1,26 @@
+using Test
+using ChainRulesDeclarationHelpers
+using ChainRulesCore
+using ChainRulesTestUtils
+using LinearAlgebra
+
+
+@testset "rrule_from_frule" begin
+    function f(x)
+        a = sin.(x)
+        b = sum(a)
+        c = b * a
+        return c
+    end
+    
+    function ChainRulesCore.frule((Δself, Δx), ::typeof(f), x)
+        a, ȧ = sin.(x), cos.(x) .* Δx 
+        b, ḃ = sum(a), sum(ȧ)
+        c, ċ = b * a, ḃ * a + b * ȧ
+        return c, ċ
+    end
+    
+    x = rand(3)
+    @test test_frule(f, x)
+    @test test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)
+end

--- a/test/rrule_from_frule.jl
+++ b/test/rrule_from_frule.jl
@@ -2,7 +2,7 @@ using Test
 using ChainRulesDeclarationHelpers
 using ChainRulesCore
 using ChainRulesTestUtils
-using LinearAlgebra
+using Zygote
 
 
 @testset "rrule_from_frule" begin
@@ -22,5 +22,7 @@ using LinearAlgebra
     
     x = rand(3)
     @test test_frule(f, x)
+
+    @rrule_from_frule f(x::AbstractArray{<:Real})
     @test test_rrule(Zygote.ZygoteRuleConfig(), f, x; check_inferred=false)
 end

--- a/test/rrule_from_frule.jl
+++ b/test/rrule_from_frule.jl
@@ -1,10 +1,3 @@
-using Test
-using ChainRulesDeclarationHelpers
-using ChainRulesCore
-using ChainRulesTestUtils
-using Zygote
-
-
 @testset "rrule_from_frule" begin
     function f(x)
         a = sin.(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
-using ChainRulesDeclarationHelpers
 using Test
+using ChainRulesDeclarationHelpers
+using ChainRulesCore
+using ChainRulesTestUtils
+using Zygote
 
 @testset "ChainRulesDeclarationHelpers" begin
     include("rrule_from_frule.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using ChainRulesDeclarationHelpers
 using Test
 
 @testset "ChainRulesDeclarationHelpers" begin
-    
+    include("rrule_from_frule.jl")
 end


### PR DESCRIPTION
This draft PR implements a proposal for a new rrule definition helper macro `@rrule_from_frule`. It generates an rrule from an already defined frule by calling-back into (reverse-mode) AD.

This is also inspired by [JAX](https://github.com/google/jax)'s approach to decomposing reverse-mode into (forward-mode) linearization + transposition (where transposition only needs rules for linear primitives).

This minimum working example illustrates the idea from a ChainRules.jl perspective:
```julia
# rrule from frule (transposition)
using Zygote
using ChainRulesCore
using LinearAlgebra

function f(x)
    a = sin.(x)
    b = sum(a)
    c = b * a
    return c
end

function ChainRulesCore.frule((Δself, Δx,), ::typeof(f), x)
    a, ȧ = sin.(x), cos.(x) .* Δx
    b, ḃ = sum(a), sum(ȧ)
    c, ċ = b * a, ḃ * a + b * ȧ
    return c, ċ
end

function ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(f), x)
    pushforward(Δfx...) = frule(Δfx, f, x)[2]
    _, back = rrule_via_ad(config, pushforward, f, x)
    f_pullback(Δy) = back(Δy)[2:end]
    return f(x), f_pullback
end

let x = rand(3)
    v = randn(3)
    w = randn(3)
    jvp(f, x, v) = frule((NoTangent(), v), f, x)[2]
    vjp(f, x, w) = rrule_via_ad(Zygote.ZygoteRuleConfig(), f, x)[2](w)[2]
    dot(w, jvp(f, x, v)) ≈ dot(vjp(f, x, w), v)
end
```
This PR aims to provide this approach as a macro that can be used like `@rrule_from_frule f(x::AbstractArray{<:Real})` to minimize boiler-plate code.